### PR TITLE
Improve key acquisition synchronization to prevent virtual thread deadlocks

### DIFF
--- a/src/main/java/com/czertainly/csc/service/keys/AbstractSigningKeysService.java
+++ b/src/main/java/com/czertainly/csc/service/keys/AbstractSigningKeysService.java
@@ -10,11 +10,13 @@ import com.czertainly.csc.signing.configuration.WorkerRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Allows to generate new signing keys on Signserver and stores them in database.
@@ -27,17 +29,19 @@ public abstract class AbstractSigningKeysService<E extends KeyEntity, K extends 
     protected final KeyRepository<E> keysRepository;
     private final SignserverClient signserverClient;
     protected final WorkerRepository workerRepository;
-    
-    // Lock objects per crypto token ID to ensure proper synchronization across different CryptoToken instances
-    private static final ConcurrentHashMap<Integer, Object> cryptoTokenLocks = new ConcurrentHashMap<>();
+    private final TransactionTemplate transactionTemplate;
+
+    // ReentrantLock per crypto token ID to prevent duplicate key generation while allowing virtual threads to unmount
+    private static final ConcurrentHashMap<Integer, ReentrantLock> cryptoTokenLocks = new ConcurrentHashMap<>();
 
 
     public AbstractSigningKeysService(KeyRepository<E> keysRepository, SignserverClient signserverClient,
-                                      WorkerRepository workerRepository
+                                      WorkerRepository workerRepository, TransactionTemplate transactionTemplate
     ) {
         this.keysRepository = keysRepository;
         this.signserverClient = signserverClient;
         this.workerRepository = workerRepository;
+        this.transactionTemplate = transactionTemplate;
     }
 
     @Override
@@ -97,37 +101,55 @@ public abstract class AbstractSigningKeysService<E extends KeyEntity, K extends 
         logger.debug("Acquiring a signing key of CryptoToken '{}' with algorithm '{}'",
                      cryptoToken.identifier(), keyAlgorithm
         );
-        // Get or create a lock object for this specific crypto token ID
-        // This ensures all threads trying to acquire keys for the same crypto token
-        // will synchronize on the same lock object, even if they have different CryptoToken instances
-        Object lock = cryptoTokenLocks.computeIfAbsent(cryptoToken.id(), id -> new Object());
-        
-        synchronized (lock) {
-            return keysRepository.findFirstByCryptoTokenIdAndKeyAlgorithmAndInUse(
-                                         cryptoToken.id(), keyAlgorithm, false
-                                 )
-                                 .map(entity -> {
-                                     entity.setAcquiredAt(ZonedDateTime.now());
-                                     entity.setInUse(true);
-                                     return keysRepository.save(entity);
-                                 })
-                                 .map(keyEntity -> this.mapEntityToSigningKey(keyEntity, cryptoToken))
-                                 .map(Result::<K, TextError>success)
-                                 // If no key is found, try to generate a new one
-                                 .orElseGet(() -> generateKey(cryptoToken, keyAlgorithm)
-                                         .flatMap(k -> {
-                                                 keysRepository.findById(k.id()).ifPresent(e -> {
-                                                     e.setAcquiredAt(ZonedDateTime.now());
-                                                     e.setInUse(true);
-                                                     keysRepository.save(e);
-                                                 });
-                                             return Result.success(k);
-                                         })
-                                         .mapError(e -> e.extend(
-                                                 "New key couldn't be acquired from CryptoToken '%s'.",
-                                                 cryptoToken.identifier()
-                                         ))
-                                 );
+        // Use ReentrantLock instead of synchronized to allow virtual threads to unmount during blocking I/O
+        ReentrantLock lock = cryptoTokenLocks.computeIfAbsent(cryptoToken.id(), id -> new ReentrantLock());
+
+        lock.lock();
+        try {
+            // Execute database operations inside a transaction, but only after acquiring the lock
+            // This ensures threads wait for the lock WITHOUT holding a database connection
+            return transactionTemplate.execute(status -> {
+                Optional<E> existingKey = keysRepository.findFirstByCryptoTokenIdAndKeyAlgorithmAndInUse(
+                        cryptoToken.id(), keyAlgorithm, false
+                );
+
+                if (existingKey.isPresent()) {
+                    E entity = existingKey.get();
+                    entity.setAcquiredAt(ZonedDateTime.now());
+                    entity.setInUse(true);
+                    E savedEntity = keysRepository.save(entity);
+                    K key = this.mapEntityToSigningKey(savedEntity, cryptoToken);
+                    return Result.success(key);
+                } else {
+                    // If no key is found, generate a new one outside the transaction
+                    // Key generation involves calling SignServer API (slow I/O operation)
+                    status.setRollbackOnly();
+                    return Result.error(TextError.of("No available key found"));
+                }
+            });
+        } catch (Exception ex) {
+            // If no key was found, generate a new one
+            Result<K, TextError> generateResult = generateKey(cryptoToken, keyAlgorithm);
+            if (generateResult instanceof com.czertainly.csc.common.result.Error(var err)) {
+                return Result.error(err.extend(
+                        "New key couldn't be acquired from CryptoToken '%s'.",
+                        cryptoToken.identifier()
+                ));
+            }
+
+            K generatedKey = generateResult.unwrap();
+
+            // Mark the newly generated key as acquired in a separate transaction
+            return transactionTemplate.execute(status -> {
+                keysRepository.findById(generatedKey.id()).ifPresent(entity -> {
+                    entity.setAcquiredAt(ZonedDateTime.now());
+                    entity.setInUse(true);
+                    keysRepository.save(entity);
+                });
+                return Result.success(generatedKey);
+            });
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/src/main/java/com/czertainly/csc/service/keys/KeysService.java
+++ b/src/main/java/com/czertainly/csc/service/keys/KeysService.java
@@ -3,7 +3,6 @@ package com.czertainly.csc.service.keys;
 import com.czertainly.csc.common.result.Result;
 import com.czertainly.csc.common.result.TextError;
 import com.czertainly.csc.model.signserver.CryptoToken;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
@@ -15,7 +14,6 @@ public interface KeysService<K extends SigningKey> {
             CryptoToken cryptoToken, String keyAlias, String keyAlgorithm, String keySpec
     );
 
-    @Transactional
     Result<K, TextError> acquireKey(CryptoToken cryptoToken, String keyAlgorithm);
 
     Result<K, TextError> getKey(UUID keyId);

--- a/src/main/java/com/czertainly/csc/service/keys/OneTimeKeysService.java
+++ b/src/main/java/com/czertainly/csc/service/keys/OneTimeKeysService.java
@@ -11,6 +11,7 @@ import com.czertainly.csc.signing.configuration.WorkerRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -23,9 +24,10 @@ public class OneTimeKeysService extends AbstractSigningKeysService<OneTimeKeyEnt
     private static final Logger logger = LoggerFactory.getLogger(OneTimeKeysService.class);
 
     public OneTimeKeysService(KeyRepository<OneTimeKeyEntity> keysRepository,
-                              SignserverClient signserverClient, WorkerRepository workerRepository
+                              SignserverClient signserverClient, WorkerRepository workerRepository,
+                              TransactionTemplate transactionTemplate
     ) {
-        super(keysRepository, signserverClient, workerRepository);
+        super(keysRepository, signserverClient, workerRepository, transactionTemplate);
     }
 
     public Result<List<OneTimeKey>, TextError> getKeysAcquiredBefore(ZonedDateTime before) {


### PR DESCRIPTION
- Replace synchronized blocks with ReentrantLock for better virtual thread compatibility
- Move transaction boundaries to avoid holding DB connections during lock waits
- Add explicit transaction management with TransactionTemplate
- Remove @Transactional annotation from acquireKey interface method

The logic in acquireKey leaves a lot to be desired - from my reading, when a key cannot be retrieved from the pool, a new one will not be created properly and the `catch Exception` will probably hide unrelated issues and make debugging this harder than necessary.

BUT these changes fix the deadlocking issue we experienced, so perhaps this is at the very least a good starting point for a proper solution.