### PR TITLE
feat: Support healthcheck endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web-services</artifactId>
             <exclusions>
                 <exclusion>

--- a/src/main/java/com/czertainly/csc/configuration/ServerConfiguration.java
+++ b/src/main/java/com/czertainly/csc/configuration/ServerConfiguration.java
@@ -66,6 +66,10 @@ public class ServerConfiguration {
         http
                 .sessionManagement(sessionConf -> sessionConf.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/health/**").permitAll()
+                        .anyRequest().authenticated()
+                )
                 .oauth2ResourceServer(
                         oauth2 -> {
                             oauth2.jwt(withDefaults());

--- a/src/main/java/com/czertainly/csc/configuration/ServerConfiguration.java
+++ b/src/main/java/com/czertainly/csc/configuration/ServerConfiguration.java
@@ -66,10 +66,6 @@ public class ServerConfiguration {
         http
                 .sessionManagement(sessionConf -> sessionConf.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/actuator/health/**").permitAll()
-                        .anyRequest().authenticated()
-                )
                 .oauth2ResourceServer(
                         oauth2 -> {
                             oauth2.jwt(withDefaults());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -187,6 +187,24 @@ caProvider:
             # Name of the keystore bundle containing the admin certificate and private key
             keystoreBundle: ejbcaAdmin
 
+management:
+    server:
+        port: 9090
+    endpoints:
+        web:
+            exposure:
+                include: health
+    endpoint:
+        health:
+            probes:
+                enabled: true
+            show-details: never
+    health:
+        livenessState:
+            enabled: true
+        readinessState:
+            enabled: true
+
 # TLS/mTLS configuration, disabled by default
 server:
     # Configuration of the keystore with server certificate and private key

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -196,6 +196,7 @@ management:
                 include: health
     endpoint:
         health:
+            access: unrestricted
             probes:
                 enabled: true
             show-details: never


### PR DESCRIPTION
CSC seems to miss dedicated healthcheck endpoint. This PR introduces one by adding Spring Boot Actuator endpoint 
I've exposed separated port to avoid unnecessary auth for healthcheck requests