### PR TITLE
NPE on signDoc when credential has null scal or signatureQualifier

### DIFF
--- a/src/main/java/com/czertainly/csc/api/management/CreateCredentialDto.java
+++ b/src/main/java/com/czertainly/csc/api/management/CreateCredentialDto.java
@@ -60,6 +60,7 @@ public record CreateCredentialDto(
                         - `2`: The hash to-be-signed is linked to the signature activation data.
                         """,
                 example = "1",
+                defaultValue = "1",
                 requiredMode = Schema.RequiredMode.NOT_REQUIRED
         )
         String scal,

--- a/src/main/java/com/czertainly/csc/api/mappers/credentials/CreateCredentialRequestMapper.java
+++ b/src/main/java/com/czertainly/csc/api/mappers/credentials/CreateCredentialRequestMapper.java
@@ -56,6 +56,12 @@ public class CreateCredentialRequestMapper {
             usePreGeneratedKey = false;
         }
 
+        // Per CSC API §11.5, scal defaults to "1" (hash-to-be-signed not linked to SAD).
+        String scal = dto.scal();
+        if (scal == null) {
+            scal = "1";
+        }
+
         CertificateReturnType certificateReturnType;
         try {
             certificateReturnType = resolveCertificateReturnType(dto.certificates());
@@ -69,7 +75,7 @@ public class CreateCredentialRequestMapper {
                 dto.userId(),
                 dto.signatureQualifier(),
                 numberOfSignaturesPerAuthorization,
-                dto.scal(),
+                scal,
                 dto.dn(),
                 dto.san(),
                 dto.description(),

--- a/src/main/java/com/czertainly/csc/service/credentials/CredentialsService.java
+++ b/src/main/java/com/czertainly/csc/service/credentials/CredentialsService.java
@@ -448,9 +448,9 @@ public class CredentialsService {
                         metadata.getUserId(),
                         metadata.getKeyAlias(),
                         metadata.getCredentialProfile(),
-                        Optional.of(metadata.getSignatureQualifier()),
+                        Optional.ofNullable(metadata.getSignatureQualifier()),
                         metadata.getMultisign(),
-                        Optional.of(metadata.getScal()),
+                        Optional.ofNullable(metadata.getScal()),
                         metadata.getCryptoTokenName(),
                         metadata.isDisabled()
                 ));

--- a/src/test/java/com/czertainly/csc/api/mappers/credentials/CreateCredentialRequestMapperTest.java
+++ b/src/test/java/com/czertainly/csc/api/mappers/credentials/CreateCredentialRequestMapperTest.java
@@ -168,6 +168,21 @@ class CreateCredentialRequestMapperTest {
     }
 
     @Test
+    void scalIsSetTo1WhenNull() {
+        // given
+        CreateCredentialDto dto = Instancio.of(CreateCredentialDto.class)
+                                           .ignore(field(CreateCredentialDto::scal))
+                                           .set(field(CreateCredentialDto::certificates), "single")
+                                           .create();
+
+        // when
+        CreateCredentialRequest request = mapper.map(dto);
+
+        // then
+        assertEquals("1", request.scal());
+    }
+
+    @Test
     void throwsOnInvalidCertificates() {
         // given
         CreateCredentialDto dto = Instancio.of(CreateCredentialDto.class)

--- a/src/test/java/com/czertainly/csc/service/credentials/CredentialsServiceTest.java
+++ b/src/test/java/com/czertainly/csc/service/credentials/CredentialsServiceTest.java
@@ -1,0 +1,81 @@
+package com.czertainly.csc.service.credentials;
+
+import com.czertainly.csc.common.result.Result;
+import com.czertainly.csc.common.result.TextError;
+import com.czertainly.csc.model.csc.CredentialMetadata;
+import com.czertainly.csc.repository.CredentialsRepository;
+import com.czertainly.csc.repository.entities.CredentialMetadataEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+class CredentialsServiceTest {
+
+    private CredentialsRepository credentialsRepository;
+    private CredentialsService credentialsService;
+
+    @BeforeEach
+    void setUp() {
+        credentialsRepository = mock(CredentialsRepository.class);
+        credentialsService = new CredentialsService(
+                null, null, null, credentialsRepository,
+                null, null, null, null, null, null, null
+        );
+    }
+
+    @Test
+    void getCredentialMetadataWrapsNullScalAndSignatureQualifierAsEmptyOptional() {
+        // given
+        UUID credentialId = UUID.randomUUID();
+        CredentialMetadataEntity entity = new CredentialMetadataEntity();
+        entity.setId(credentialId);
+        entity.setUserId("user-1");
+        entity.setKeyAlias("alias");
+        entity.setCredentialProfile("profile");
+        entity.setSignatureQualifier(null);
+        entity.setMultisign(1);
+        entity.setScal(null);
+        entity.setCryptoTokenName("token");
+        entity.setDisabled(false);
+        when(credentialsRepository.findById(credentialId)).thenReturn(Optional.of(entity));
+
+        // when
+        Result<CredentialMetadata, TextError> result = credentialsService.getCredentialMetadata(credentialId, null);
+
+        // then
+        CredentialMetadata metadata = result.unwrap();
+        assertTrue(metadata.signatureQualifier().isEmpty());
+        assertTrue(metadata.scal().isEmpty());
+    }
+
+    @Test
+    void getCredentialMetadataWrapsPresentScalAndSignatureQualifierAsOptional() {
+        // given
+        UUID credentialId = UUID.randomUUID();
+        CredentialMetadataEntity entity = new CredentialMetadataEntity();
+        entity.setId(credentialId);
+        entity.setUserId("user-1");
+        entity.setKeyAlias("alias");
+        entity.setCredentialProfile("profile");
+        entity.setSignatureQualifier("eu_eidas_ades");
+        entity.setMultisign(1);
+        entity.setScal("1");
+        entity.setCryptoTokenName("token");
+        entity.setDisabled(false);
+        when(credentialsRepository.findByIdAndUserId(credentialId, "user-1")).thenReturn(Optional.of(entity));
+
+        // when
+        Result<CredentialMetadata, TextError> result = credentialsService.getCredentialMetadata(credentialId, "user-1");
+
+        // then
+        CredentialMetadata metadata = result.unwrap();
+        assertEquals(Optional.of("eu_eidas_ades"), metadata.signatureQualifier());
+        assertEquals(Optional.of("1"), metadata.scal());
+    }
+}


### PR DESCRIPTION
## Changes

- `CreateCredentialRequestMapper`: default `scal` to `"1"` when omitted in the create request (per CSC API §11.5).
- `CredentialsService.getCredentialMetadata`: `Optional.of` → `Optional.ofNullable` for `signatureQualifier` and `scal`.
- `CreateCredentialDto`: OpenAPI schema for `scal` declares `defaultValue = "1"`.
- New test `scalIsSetTo1WhenNull` in `CreateCredentialRequestMapperTest`.