### PR TITLE
Comment out unused idpClient SSL bundle declaration

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -264,11 +264,14 @@ spring:
                 #        type: "PKCS12"
                 #        location: /opt/cscapi/management-truststore.p12
                 #        password: password
-                idpClient:
-                    keystore:
-                        type: "PKCS12"
-                        location: /opt/cscapi/idp/client-keystore.p12
-                        password: password
+                # Uncomment only when idp.client.authType: CERTIFICATE. If declared,
+                # the keystore is loaded at startup regardless of authType and the
+                # application will fail to start if the file is absent.
+                # idpClient:
+                #     keystore:
+                #         type: "PKCS12"
+                #         location: /opt/cscapi/idp/client-keystore.p12
+                #         password: password
                 ejbcaAdmin:
                     keystore:
                         type: "PKCS12"


### PR DESCRIPTION
### Changed
- `src/main/resources/application.yml`: comment out the `spring.ssl.bundle.jks.idpClient` block. The keystore is loaded at startup regardless of `idp.client.authType`, so a missing `/opt/cscapi/idp/client-keystore.p12` prevents the application from starting even when `authType: NONE`. Operators using `authType: CERTIFICATE` must uncomment the block and provide the keystore.