### PR TITLE
Treat blank proxy URL env vars as unset

### DIFF
--- a/src/main/java/com/otilm/csc/configuration/proxy/ProxySettings.java
+++ b/src/main/java/com/otilm/csc/configuration/proxy/ProxySettings.java
@@ -121,7 +121,7 @@ public class ProxySettings {
     }
 
     static ProxySettings parse(String protocol, String proxyUrl, String noProxy) {
-        if (proxyUrl == null) {
+        if (proxyUrl == null || proxyUrl.isBlank()) {
             return null;
         }
         try {


### PR DESCRIPTION
Fixes #177

## Summary
- `ProxySettings.parse()` now treats blank `proxyUrl` values the same as `null`, preventing the spurious "host not specified" ERROR on startup when the Dockerfile's empty `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` defaults are in effect.